### PR TITLE
Event support for animation

### DIFF
--- a/components/init.lua
+++ b/components/init.lua
@@ -132,11 +132,12 @@ end
 
 function components.index(i) return i or 0 end
 function components.frame_sequence(s) return s or {} end
-function components.animation_args(playing, once, mode)
+function components.animation_args(playing, once, mode, id)
     return {
         playing=playing or false,
         once=once or false,
-        mode=mode or "forward"
+        mode=mode or "forward",
+        id=id
     }
 end
 

--- a/core/atlas.lua
+++ b/core/atlas.lua
@@ -27,6 +27,10 @@ local function read_json(path)
     end
 end
 
+local function get_event_tag(tag)
+    return string.match(tag, "event<(.*)>")
+end
+
 function Atlas.create(path)
     local sheet = gfx.newImage(path .. "/atlas.png")
     local data = read_json(path   .. "/atlas.json")
@@ -63,11 +67,18 @@ function Atlas.create(path)
 
     for _, tag in ipairs(data.meta.frameTags) do
         local name = tag.name
-        if this.tags[name] then
-            errorf("Naming conflict <%s>", name)
-        end
 
-        this.tags[name] = dict{to=tag.to, from=tag.from}
+        local event = get_event_tag(name)
+        if event then
+            for i = tag.from + 1, tag.to + 1 do
+                frames[i].events[event] = true
+            end
+        else
+            if this.tags[name] then
+                errorf("Naming conflict <%s>", name)
+            end
+            this.tags[name] = dict{to=tag.to, from=tag.from}
+        end
     end
 
 

--- a/core/frame.lua
+++ b/core/frame.lua
@@ -55,4 +55,12 @@ function frame:draw(...)
     end
 end
 
+function frame:get_slice(slice_key, origin_key)
+    origin_key = origin_key or "body"
+    local origin_slice = self.slices[origin_key] or spatial()
+    local slice = self.slices[slice_key]
+    if not slice then return end
+    return slice:relative(origin_slice)
+end
+
 return frame

--- a/core/frame.lua
+++ b/core/frame.lua
@@ -12,6 +12,7 @@ function frame.create(image, slices, quad, offset)
     this.image = image
     this.quad = quad
     this.slices = slices
+    this.events = dict()
     this.offset = offset or vec2(0, 0)
     this.deltas = dict{}
     this.deltas_init = dict{}


### PR DESCRIPTION
Adds support for tag based animation events.

Basically any tag in aseprite with the name event<some_name> will result in an event of that name being emitted.

Specifically an event of the pattern animation_event:some_name will emitted upon entering frames with said event tag. And an event of the pattern animation_event:some_name:end will be emitted upon leaving said event frames.

The intention is to use this to time hitboxes, sounds and other animation driven stuff.