### PR TITLE
refactored ecs_world on_entity_destroyed to allow for multiple cleanups

### DIFF
--- a/nodeworks/ecs/entity.lua
+++ b/nodeworks/ecs/entity.lua
@@ -59,7 +59,8 @@ function entity_table.create(strong_tables)
         {
             components = {},
             strong_tables = strong_tables,
-            stored_entities = {}
+            stored_entities = {},
+            on_entity_destroyed = {}
         },
         entity_table
     )
@@ -131,7 +132,9 @@ function entity_table:destroy(id)
     end
 
     if self.on_entity_destroyed then
-        self.on_entity_destroyed(id, values_destroyed)
+        for _, func in pairs(self.on_entity_destroyed) do
+            func(id, values_destroyed)
+        end
     end
 
     self.stored_entities[id] = nil

--- a/nodeworks/system/collision.lua
+++ b/nodeworks/system/collision.lua
@@ -152,6 +152,11 @@ function Collision.default_filter()
     return "slide"
 end
 
+function Collision.on_entity_destroyed(id, values_destroyed)
+    local bump_world = values_destroyed[nw.component.bump_world]
+    if bump_world and bump_world:hasItem(id) then bump_world:remove(id) end
+end
+
 local default_instance = Collision.create()
 
 local assemble = {}
@@ -172,12 +177,19 @@ function assemble.set_bump_world(entity, bump_world)
     entity:set(nw.component.bump_world, bump_world)
 
     add_entity_to_world(entity)
+
+    local on_entity_destroyed = entity:world().on_entity_destroyed
+
+    if not on_entity_destroyed.collision then
+        on_entity_destroyed.collision = Collision.on_entity_destroyed
+    end
 end
 
 function assemble.init_entity(entity, x, y, hitbox, bump_world)
     entity
         :assemble(assemble.set_hitbox, hitbox:unpack())
         :assemble(assemble.set_bump_world, bump_world)
+
     default_instance:warp_to(entity, x, y)
 end
 
@@ -190,6 +202,12 @@ return function(ctx)
 end
 
 --[[
+
+function ecs_world.on_entity_destroyed.collision(id, values_destroyed)
+    local bump_world = values_destroyed[nw.component.bump_world]
+    if bump_world and bump_world:has(id) then bump_world:remove(id) end
+end
+
 collision(ctx):move_to(entity, 100, 100)
 ecs_world:entity():assemble(collision().init_entity, x, y, hitbox, bump_world)
 

--- a/test/system/collision.lua
+++ b/test/system/collision.lua
@@ -176,4 +176,15 @@ T("collision", function(T)
         T:assert(ctx.moved:peek() == entity)
         T:assert(ctx.collision:peek().item == entity.id)
     end)
+
+    T("cleanup", function(T)
+        local entity = ecs_world:entity()
+            :assemble(
+                collision().assemble.init_entity,
+                200, 300, hitbox, bump_world
+            )
+        T:assert(bump_world:hasItem(entity.id))
+        entity:destroy()
+        T:assert(not bump_world:hasItem(entity.id))
+    end)
 end)


### PR DESCRIPTION
Also collision now automatically setups a cleanup handle